### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -239,8 +239,7 @@ new_json='{
       "peer_public_key": "'"$i_w_pb"'",
       "reserved": ['$i_w_res'],  
 
-      "mtu": 1120,
-      "fake_packets": "5-10"
+      "mtu": 1120
     }'
 
 


### PR DESCRIPTION
حذف نویز پکت برای وایرگارد دوم

با توجه به عبور ترافیک وایرگارد دوم از وایرگارد آی آر نیاز به نویز پکت نیست..